### PR TITLE
Exclude unsupported AZs during auto-VPC creation

### DIFF
--- a/modules/terraform-cdp-aws-pre-reqs/modules/vpc/defaults.tf
+++ b/modules/terraform-cdp-aws-pre-reqs/modules/vpc/defaults.tf
@@ -14,11 +14,11 @@
 
 locals {
 
-  azs_to_exclude = [ "us-east-1e"] # List of AWS AZs which are not supported by CDP
+  azs_to_exclude = ["us-east-1e"] # List of AWS AZs which are not supported by CDP
 
-    # Create a list of supported zones in the region
+  # Create a list of supported zones in the region
   zones_in_region = tolist(setsubtract(data.aws_availability_zones.zones_in_region.names, local.azs_to_exclude))
-  
+
   # ------- Determine subnet details from inputs -------
   subnets_required = {
     total   = (var.deployment_template == "public") ? length(local.zones_in_region) : 2 * length(local.zones_in_region)

--- a/modules/terraform-cdp-aws-pre-reqs/modules/vpc/defaults.tf
+++ b/modules/terraform-cdp-aws-pre-reqs/modules/vpc/defaults.tf
@@ -13,10 +13,16 @@
 # limitations under the License.
 
 locals {
+
+  azs_to_exclude = [ "us-east-1e"] # List of AWS AZs which are not supported by CDP
+
+    # Create a list of supported zones in the region
+  zones_in_region = tolist(setsubtract(data.aws_availability_zones.zones_in_region.names, local.azs_to_exclude))
+  
   # ------- Determine subnet details from inputs -------
   subnets_required = {
-    total   = (var.deployment_template == "public") ? length(data.aws_availability_zones.zones_in_region.names) : 2 * length(data.aws_availability_zones.zones_in_region.names)
-    public  = length(data.aws_availability_zones.zones_in_region.names)
-    private = (var.deployment_template == "public") ? 0 : length(data.aws_availability_zones.zones_in_region.names)
+    total   = (var.deployment_template == "public") ? length(local.zones_in_region) : 2 * length(local.zones_in_region)
+    public  = length(local.zones_in_region)
+    private = (var.deployment_template == "public") ? 0 : length(local.zones_in_region)
   }
 }

--- a/modules/terraform-cdp-aws-pre-reqs/modules/vpc/main.tf
+++ b/modules/terraform-cdp-aws-pre-reqs/modules/vpc/main.tf
@@ -19,11 +19,11 @@ module "cdp_vpc" {
   name = "${var.env_prefix}-net"
   cidr = var.vpc_cidr
 
-  azs = [for v in data.aws_availability_zones.zones_in_region.names : v]
+  azs = [for v in local.zones_in_region : v]
   private_subnets = (local.subnets_required.private == 0 ?
     [] :
     [
-      for k, v in data.aws_availability_zones.zones_in_region.names : cidrsubnet(var.vpc_cidr, ceil(log(local.subnets_required.total, 2)), local.subnets_required.public + k)
+      for k, v in local.zones_in_region : cidrsubnet(var.vpc_cidr, ceil(log(local.subnets_required.total, 2)), local.subnets_required.public + k)
     ]
   )
   private_subnet_tags = {
@@ -33,7 +33,7 @@ module "cdp_vpc" {
   public_subnets = (local.subnets_required.public == 0 ?
     [] :
     [
-      for k, v in data.aws_availability_zones.zones_in_region.names : cidrsubnet(var.vpc_cidr, ceil(log(local.subnets_required.total, 2)), k)
+      for k, v in local.zones_in_region : cidrsubnet(var.vpc_cidr, ceil(log(local.subnets_required.total, 2)), k)
     ]
   )
 


### PR DESCRIPTION
As per the docs on [Supported AWS regions](https://docs.cloudera.com/cdp-public-cloud/cloud/requirements-aws/topics/mc-aws-req-region.html#mc-aws-req-region), the `us-east-1e` Availability Zone is not supported for CDP deployments. 

This PR removes these unsupported AZs when the option to create the networking infrastructure (VPCs, subnets, etc.) is specified.

Fixes #5 