### PR TITLE
Fix lint warnings

### DIFF
--- a/modules/terraform-cdp-aws-pre-reqs/examples/ex01-minimal_inputs/main.tf
+++ b/modules/terraform-cdp-aws-pre-reqs/examples/ex01-minimal_inputs/main.tf
@@ -23,7 +23,6 @@ module "ex01_minimal_inputs" {
   env_prefix = var.env_prefix
   aws_region = var.aws_region
 
-  aws_profile  = var.aws_profile
   aws_key_pair = var.aws_key_pair
 
   deployment_template = var.deployment_template

--- a/modules/terraform-cdp-aws-pre-reqs/examples/ex02-existing-vpc/main.tf
+++ b/modules/terraform-cdp-aws-pre-reqs/examples/ex02-existing-vpc/main.tf
@@ -23,7 +23,6 @@ module "ex02_existing_vpc" {
   env_prefix = var.env_prefix
   aws_region = var.aws_region
 
-  aws_profile  = var.aws_profile
   aws_key_pair = var.aws_key_pair
 
   deployment_template = var.deployment_template

--- a/modules/terraform-cdp-aws-pre-reqs/examples/ex03-create-keypair/main.tf
+++ b/modules/terraform-cdp-aws-pre-reqs/examples/ex03-create-keypair/main.tf
@@ -43,7 +43,6 @@ module "ex01_create_keypair" {
   env_prefix = var.env_prefix
   aws_region = var.aws_region
 
-  aws_profile  = var.aws_profile
   aws_key_pair = aws_key_pair.cdp_keypair.key_name
 
   deployment_template = var.deployment_template

--- a/modules/terraform-cdp-aws-pre-reqs/variables.tf
+++ b/modules/terraform-cdp-aws-pre-reqs/variables.tf
@@ -13,14 +13,6 @@
 # limitations under the License.
 
 # ------- Global settings -------
-variable "aws_profile" {
-  type        = string
-  description = "Profile for AWS cloud credentials"
-
-  # Profile is default unless explicitly specified
-  default = "default"
-}
-
 variable "infra_type" {
   type        = string
   description = "Cloud Provider to deploy CDP."
@@ -213,14 +205,6 @@ variable "security_group_knox_name" {
   description = "Knox Security Group for CDP environment"
 
   default = null
-}
-
-variable "cdp_control_plane_cidrs" {
-  type = list(string)
-
-  description = "CIDR for access to CDP Control Plane"
-
-  default = ["52.36.110.208/32", "52.40.165.49/32", "35.166.86.177/32"]
 }
 
 variable "ingress_extra_cidrs_and_ports" {


### PR DESCRIPTION
PR to fix tflint warnings by removing unused `aws_profile` and `cdp_control_plane_cidrs` variables from the AWS pre-reqs module.
Examples were also updated to remove these variables.