### PR TITLE
Ensure only private subnets used for CDP private & semi-private deployments

### DIFF
--- a/modules/terraform-cdp-aws-pre-reqs/cdp_deploy.tf
+++ b/modules/terraform-cdp-aws-pre-reqs/cdp_deploy.tf
@@ -46,7 +46,7 @@ resource "local_file" "cdp_deployment_template" {
     plat__aws_vpc_id             = local.vpc_id
     plat__aws_public_subnet_ids  = jsonencode(local.public_subnet_ids)
     plat__aws_private_subnet_ids = jsonencode(local.private_subnet_ids)
-    plat__aws_subnets_for_cdp    = (var.deployment_template == "public") ? jsonencode(concat(local.public_subnet_ids, local.private_subnet_ids )) : jsonencode(local.private_subnet_ids )
+    plat__aws_subnets_for_cdp    = (var.deployment_template == "public") ? jsonencode(concat(local.public_subnet_ids, local.private_subnet_ids)) : jsonencode(local.private_subnet_ids)
 
     plat__aws_storage_location = "s3a://${local.data_storage.data_storage_bucket}${local.storage_suffix}"
     plat__aws_log_location     = "s3a://${local.log_storage.log_storage_bucket}${local.storage_suffix}/${local.log_storage.log_storage_object}"

--- a/modules/terraform-cdp-aws-pre-reqs/cdp_deploy.tf
+++ b/modules/terraform-cdp-aws-pre-reqs/cdp_deploy.tf
@@ -46,6 +46,7 @@ resource "local_file" "cdp_deployment_template" {
     plat__aws_vpc_id             = local.vpc_id
     plat__aws_public_subnet_ids  = jsonencode(local.public_subnet_ids)
     plat__aws_private_subnet_ids = jsonencode(local.private_subnet_ids)
+    plat__aws_subnets_for_cdp    = (var.deployment_template == "public") ? jsonencode(concat(local.public_subnet_ids, local.private_subnet_ids )) : jsonencode(local.private_subnet_ids )
 
     plat__aws_storage_location = "s3a://${local.data_storage.data_storage_bucket}${local.storage_suffix}"
     plat__aws_log_location     = "s3a://${local.log_storage.log_storage_bucket}${local.storage_suffix}/${local.log_storage.log_storage_object}"

--- a/modules/terraform-cdp-aws-pre-reqs/playbook_setup_cdp.yml
+++ b/modules/terraform-cdp-aws-pre-reqs/playbook_setup_cdp.yml
@@ -104,7 +104,7 @@
         public_key_id: "{{ plat__public_key_id }}"
         workload_analytics: "{{ plat__workload_analytics }}"
         vpc_id: "{{ plat__aws_vpc_id }}"
-        subnet_ids: "{{ plat__aws_public_subnet_ids | union(plat__aws_private_subnet_ids) }}"
+        subnet_ids: "{{ plat__aws_subnets_for_cdp }}"
         tags: "{{ plat__tags }}"
         tunnel: "{{ plat__tunnel }}"
         endpoint_access_scheme: "{{ plat__endpoint_access_scheme | default(omit) }}"

--- a/modules/terraform-cdp-aws-pre-reqs/templates/cdp_config.yml.tpl
+++ b/modules/terraform-cdp-aws-pre-reqs/templates/cdp_config.yml.tpl
@@ -38,6 +38,7 @@ plat__region: ${plat__region}
 plat__aws_vpc_id: ${plat__aws_vpc_id}
 plat__aws_public_subnet_ids: ${plat__aws_public_subnet_ids}
 plat__aws_private_subnet_ids: ${plat__aws_private_subnet_ids}
+plat__aws_subnets_for_cdp: ${plat__aws_subnets_for_cdp}
 
 plat__aws_storage_location: ${plat__aws_storage_location}
 plat__aws_log_location: ${plat__aws_log_location}


### PR DESCRIPTION
For private and semi-private deployments we need to ensure that the CDP environment uses only private subnets. 

Otherwise nodes associated with the CDP environment can be provisioned on public subnets and get public IP addresses.