### PR TITLE
Updates for CDP data storage locations

### DIFF
--- a/modules/terraform-cdp-aws-pre-reqs/cdp_deploy.tf
+++ b/modules/terraform-cdp-aws-pre-reqs/cdp_deploy.tf
@@ -47,7 +47,7 @@ resource "local_file" "cdp_deployment_template" {
     plat__aws_public_subnet_ids  = jsonencode(local.public_subnet_ids)
     plat__aws_private_subnet_ids = jsonencode(local.private_subnet_ids)
 
-    plat__aws_storage_location = "s3a://${local.data_storage.data_storage_bucket}${local.storage_suffix}"
+    plat__aws_storage_location = "s3a://${local.data_storage.data_storage_bucket}${local.storage_suffix}/${local.data_storage.data_storage_object}"
     plat__aws_log_location     = "s3a://${local.log_storage.log_storage_bucket}${local.storage_suffix}/${local.log_storage.log_storage_object}"
     plat__aws_backup_location  = "s3a://${local.backup_storage.backup_storage_bucket}${local.storage_suffix}/${local.backup_storage.backup_storage_object}"
 

--- a/modules/terraform-cdp-aws-pre-reqs/defaults.tf
+++ b/modules/terraform-cdp-aws-pre-reqs/defaults.tf
@@ -72,7 +72,7 @@ locals {
   storage_suffix = var.random_id_for_bucket ? "-${one(random_id.bucket_suffix).hex}" : ""
 
   data_storage = {
-    data_storage_bucket  = try(var.data_storage.data_storage_bucket, "${var.env_prefix}-buk")
+    data_storage_bucket = try(var.data_storage.data_storage_bucket, "${var.env_prefix}-buk")
     data_storage_object = try(var.data_storage.data_storage_object, "data/")
   }
 

--- a/modules/terraform-cdp-aws-pre-reqs/defaults.tf
+++ b/modules/terraform-cdp-aws-pre-reqs/defaults.tf
@@ -73,12 +73,12 @@ locals {
 
   data_storage = {
     data_storage_bucket  = try(var.data_storage.data_storage_bucket, "${var.env_prefix}-buk")
-    data_storage_objects = try(var.data_storage.data_storage_objects, ["ranger/audit/"])
+    data_storage_object = try(var.data_storage.data_storage_object, "data/")
   }
 
   log_storage = {
     log_storage_bucket = try(var.log_storage.log_storage_bucket, local.data_storage.data_storage_bucket)
-    log_storage_object = try(var.log_storage.log_storage_object, "logs")
+    log_storage_object = try(var.log_storage.log_storage_object, "logs/")
   }
 
   backup_storage = {

--- a/modules/terraform-cdp-aws-pre-reqs/examples/ex04-all_inputs_specified/variables.tf
+++ b/modules/terraform-cdp-aws-pre-reqs/examples/ex04-all_inputs_specified/variables.tf
@@ -141,8 +141,8 @@ variable "random_id_for_bucket" {
 
 variable "data_storage" {
   type = object({
-    data_storage_bucket  = string
-    data_storage_object =  string
+    data_storage_bucket = string
+    data_storage_object = string
   })
 
   description = "Storage locations for CDP environment"

--- a/modules/terraform-cdp-aws-pre-reqs/examples/ex04-all_inputs_specified/variables.tf
+++ b/modules/terraform-cdp-aws-pre-reqs/examples/ex04-all_inputs_specified/variables.tf
@@ -142,7 +142,7 @@ variable "random_id_for_bucket" {
 variable "data_storage" {
   type = object({
     data_storage_bucket  = string
-    data_storage_objects = list(string)
+    data_storage_object =  string
   })
 
   description = "Storage locations for CDP environment"

--- a/modules/terraform-cdp-aws-pre-reqs/main.tf
+++ b/modules/terraform-cdp-aws-pre-reqs/main.tf
@@ -138,11 +138,9 @@ resource "aws_s3_bucket" "cdp_storage_locations" {
 # Data Storage Objects
 resource "aws_s3_object" "cdp_data_storage_object" {
 
-  for_each = toset(local.data_storage.data_storage_objects)
-
   bucket = var.random_id_for_bucket ? "${local.data_storage.data_storage_bucket}-${one(random_id.bucket_suffix).hex}" : local.data_storage.data_storage_bucket
 
-  key          = each.key
+  key          = local.backup_storage.backup_storage_object
   content_type = "application/x-directory"
 
   depends_on = [

--- a/modules/terraform-cdp-aws-pre-reqs/outputs.tf
+++ b/modules/terraform-cdp-aws-pre-reqs/outputs.tf
@@ -150,19 +150,19 @@ output "aws_private_subnet_ids" {
 }
 
 output "aws_storage_location" {
-  value = "s3a://${local.data_storage.data_storage_bucket}${local.storage_suffix}"
+  value = "s3a://${local.data_storage.data_storage_bucket}${local.storage_suffix}/${local.data_storage.data_storage_object}"
 
   description = "AWS data storage location"
 }
 
 output "aws_log_location" {
-  value = "s3a://${local.log_storage.log_storage_bucket}${local.storage_suffix}"
+  value = "s3a://${local.log_storage.log_storage_bucket}${local.storage_suffix}/${local.log_storage.log_storage_object}"
 
   description = "AWS log storage location"
 }
 
 output "aws_backup_location" {
-  value = "s3a://${local.backup_storage.backup_storage_bucket}${local.storage_suffix}"
+  value = "s3a://${local.backup_storage.backup_storage_bucket}${local.storage_suffix}/${local.backup_storage.backup_storage_object}"
 
   description = "AWS backup storage location"
 }

--- a/modules/terraform-cdp-aws-pre-reqs/variables.tf
+++ b/modules/terraform-cdp-aws-pre-reqs/variables.tf
@@ -248,7 +248,7 @@ variable "random_id_for_bucket" {
 
 variable "data_storage" {
   type = object({
-    data_storage_bucket  = string
+    data_storage_bucket = string
     data_storage_object = string
   })
 

--- a/modules/terraform-cdp-aws-pre-reqs/variables.tf
+++ b/modules/terraform-cdp-aws-pre-reqs/variables.tf
@@ -249,10 +249,10 @@ variable "random_id_for_bucket" {
 variable "data_storage" {
   type = object({
     data_storage_bucket  = string
-    data_storage_objects = list(string)
+    data_storage_object = string
   })
 
-  description = "Storage locations for CDP environment"
+  description = "Data storage locations for CDP environment"
 
   default = null
 }


### PR DESCRIPTION
Update the AWS module outputs and cdp_config template file to include the data storage object location.
The data storage location is also changed from a list to a single string item to align with the log and backup locations.