### PR TITLE
Fix policy placeholders and use backup storage location

### DIFF
--- a/modules/terraform-cdp-aws-pre-reqs/README.md
+++ b/modules/terraform-cdp-aws-pre-reqs/README.md
@@ -17,7 +17,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 4.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.67.0 |
 | <a name="provider_external"></a> [external](#provider\_external) | 2.3.1 |
 | <a name="provider_http"></a> [http](#provider\_http) | 3.2.1 |
 | <a name="provider_local"></a> [local](#provider\_local) | 2.2.3 |
@@ -127,6 +127,7 @@
 | <a name="input_datalake_restore_policy_doc"></a> [datalake\_restore\_policy\_doc](#input\_datalake\_restore\_policy\_doc) | Location of Datalake Restore Data Access Policy | `string` | `null` | no |
 | <a name="input_datalake_restore_policy_name"></a> [datalake\_restore\_policy\_name](#input\_datalake\_restore\_policy\_name) | Datalake restore Data Access Policy Name | `string` | `null` | no |
 | <a name="input_datalake_scale"></a> [datalake\_scale](#input\_datalake\_scale) | The scale of the datalake. Valid values are LIGHT\_DUTY, MEDIUM\_DUTY\_HA. | `string` | `null` | no |
+| <a name="input_datalake_version"></a> [datalake\_version](#input\_datalake\_version) | The Datalake Runtime version. Valid values are semantic versions, e.g. 7.2.16 | `string` | `"7.2.16"` | no |
 | <a name="input_deploy_cdp"></a> [deploy\_cdp](#input\_deploy\_cdp) | Deploy the CDP environment as part of Terraform | `bool` | `true` | no |
 | <a name="input_enable_ccm_tunnel"></a> [enable\_ccm\_tunnel](#input\_enable\_ccm\_tunnel) | Flag to enable Cluster Connectivity Manager tunnel. If false then access from Cloud to CDP Control Plane CIDRs is required from via SG ingress | `bool` | `true` | no |
 | <a name="input_enable_raz"></a> [enable\_raz](#input\_enable\_raz) | Flag to enable Ranger Authorization Service (RAZ) | `bool` | `true` | no |

--- a/modules/terraform-cdp-aws-pre-reqs/defaults.tf
+++ b/modules/terraform-cdp-aws-pre-reqs/defaults.tf
@@ -159,7 +159,7 @@ locals {
   datalake_backup_policy_doc_processed = replace(
     replace(
     data.http.datalake_backup_policy_doc.response_body, "$${ARN_PARTITION}", "aws"),
-  "<BACKUP_LOCATION_BASE>", "${local.backup_storage.backup_storage_bucket}${local.storage_suffix}")
+  "$${BACKUP_LOCATION_BASE}", "${local.backup_storage.backup_storage_bucket}${local.storage_suffix}")
 
   # ...then assign either input or downloaded policy doc to var used in resource
   datalake_backup_policy_doc = coalesce(var.datalake_backup_policy_doc, local.datalake_backup_policy_doc_processed)
@@ -172,7 +172,7 @@ locals {
   datalake_restore_policy_doc_processed = replace(
     replace(
     data.http.datalake_restore_policy_doc.response_body, "$${ARN_PARTITION}", "aws"),
-  "<your-backup-bucket>", "${local.backup_storage.backup_storage_bucket}${local.storage_suffix}")
+  "$${BACKUP_LOCATION_BASE}", "${local.backup_storage.backup_storage_bucket}${local.storage_suffix}")
 
   # ...then assign either input or downloaded policy doc to var used in resource
   datalake_restore_policy_doc = coalesce(var.datalake_restore_policy_doc, local.datalake_restore_policy_doc_processed)

--- a/modules/terraform-cdp-aws-pre-reqs/playbook_setup_cdp.yml
+++ b/modules/terraform-cdp-aws-pre-reqs/playbook_setup_cdp.yml
@@ -103,6 +103,7 @@
             knox_sg: "{{ plat__aws_security_group_knox_id }}"
             log_location: "{{ plat__aws_log_location }}"
             log_identity: "{{ plat__aws_log_instance_profile_arn }}"
+            backup_location: "{{ plat__aws_backup_location }}"
             public_key_id: "{{ plat__public_key_id }}"
             workload_analytics: "{{ plat__workload_analytics }}"
             vpc_id: "{{ plat__aws_vpc_id }}"

--- a/modules/terraform-cdp-aws-pre-reqs/templates/cdp_config.yml.tpl
+++ b/modules/terraform-cdp-aws-pre-reqs/templates/cdp_config.yml.tpl
@@ -43,6 +43,7 @@ plat__aws_subnets_for_cdp: ${plat__aws_subnets_for_cdp}
 
 plat__aws_storage_location: ${plat__aws_storage_location}
 plat__aws_log_location: ${plat__aws_log_location}
+plat__aws_backup_location: ${plat__aws_backup_location}
 
 plat__public_key_id: ${plat__public_key_id}
 plat__aws_security_group_default_id: ${plat__aws_security_group_default_id}


### PR DESCRIPTION
* Update replacement of placeholders in the backup and restore IAM polices. Fixes #18
* Make use of the backup storage location variable in the CDP deployment. Addresses #15 