### PR TITLE
Improve subnet CIDR calculation

### DIFF
--- a/modules/terraform-cdp-aws-pre-reqs/main.tf
+++ b/modules/terraform-cdp-aws-pre-reqs/main.tf
@@ -25,9 +25,9 @@ module "aws_cdp_vpc" {
   private_network_extensions = var.private_network_extensions
   env_prefix                 = var.env_prefix
   tags                       = local.env_tags
-  
+
   private_cidr_range = var.private_cidr_range
-  public_cidr_range = var.public_cidr_range
+  public_cidr_range  = var.public_cidr_range
 }
 
 # ------- Security Groups -------

--- a/modules/terraform-cdp-aws-pre-reqs/main.tf
+++ b/modules/terraform-cdp-aws-pre-reqs/main.tf
@@ -25,7 +25,9 @@ module "aws_cdp_vpc" {
   private_network_extensions = var.private_network_extensions
   env_prefix                 = var.env_prefix
   tags                       = local.env_tags
-
+  
+  private_cidr_range = var.private_cidr_range
+  public_cidr_range = var.public_cidr_range
 }
 
 # ------- Security Groups -------

--- a/modules/terraform-cdp-aws-pre-reqs/modules/vpc/defaults.tf
+++ b/modules/terraform-cdp-aws-pre-reqs/modules/vpc/defaults.tf
@@ -25,4 +25,9 @@ locals {
     public  = (var.deployment_template == "private") ? (var.private_network_extensions ? 1 : 0) : length(local.zones_in_region)
     private = (var.deployment_template == "public") ? 0 : length(local.zones_in_region)
   }
+  
+  vpc_cidr_range = split("/",var.vpc_cidr)[1]
+  
+  # Calculate the first suitable CIDR range for public subnets after private subnets have been allocated.
+  public_subnet_offset = ceil(local.subnets_required.private * pow(2, 32-var.private_cidr_range)/pow(2, 32-var.public_cidr_range))
 }

--- a/modules/terraform-cdp-aws-pre-reqs/modules/vpc/defaults.tf
+++ b/modules/terraform-cdp-aws-pre-reqs/modules/vpc/defaults.tf
@@ -29,6 +29,6 @@ locals {
   # Extract the VPC CIDR range from the user-provided CIDR
   vpc_cidr_range = split("/",var.vpc_cidr)[1]
   
-  # Calculate the first suitable CIDR range for public subnets after private subnets have been allocated.
+  # Calculate the first suitable CIDR range for public subnets after private subnets have been allocated (normalize the offset, expressed as a multiplier of public subnet ranges)
   public_subnet_offset = ceil(local.subnets_required.private * pow(2, 32-var.private_cidr_range)/pow(2, 32-var.public_cidr_range))
 }

--- a/modules/terraform-cdp-aws-pre-reqs/modules/vpc/defaults.tf
+++ b/modules/terraform-cdp-aws-pre-reqs/modules/vpc/defaults.tf
@@ -25,10 +25,10 @@ locals {
     public  = (var.deployment_template == "private") ? (var.private_network_extensions ? 1 : 0) : length(local.zones_in_region)
     private = (var.deployment_template == "public") ? 0 : length(local.zones_in_region)
   }
-  
+
   # Extract the VPC CIDR range from the user-provided CIDR
-  vpc_cidr_range = split("/",var.vpc_cidr)[1]
-  
+  vpc_cidr_range = split("/", var.vpc_cidr)[1]
+
   # Calculate the first suitable CIDR range for public subnets after private subnets have been allocated (normalize the offset, expressed as a multiplier of public subnet ranges)
-  public_subnet_offset = ceil(local.subnets_required.private * pow(2, 32-var.private_cidr_range)/pow(2, 32-var.public_cidr_range))
+  public_subnet_offset = ceil(local.subnets_required.private * pow(2, 32 - var.private_cidr_range) / pow(2, 32 - var.public_cidr_range))
 }

--- a/modules/terraform-cdp-aws-pre-reqs/modules/vpc/defaults.tf
+++ b/modules/terraform-cdp-aws-pre-reqs/modules/vpc/defaults.tf
@@ -26,6 +26,7 @@ locals {
     private = (var.deployment_template == "public") ? 0 : length(local.zones_in_region)
   }
   
+  # Extract the VPC CIDR range from the user-provided CIDR
   vpc_cidr_range = split("/",var.vpc_cidr)[1]
   
   # Calculate the first suitable CIDR range for public subnets after private subnets have been allocated.

--- a/modules/terraform-cdp-aws-pre-reqs/modules/vpc/main.tf
+++ b/modules/terraform-cdp-aws-pre-reqs/modules/vpc/main.tf
@@ -23,7 +23,7 @@ module "cdp_vpc" {
   private_subnets = (local.subnets_required.private == 0 ?
     [] :
     [
-      for i in range(local.subnets_required.private) : cidrsubnet(var.vpc_cidr, ceil(log(local.subnets_required.total, 2)), local.subnets_required.public + i)
+      for i in range(local.subnets_required.private) : cidrsubnet(var.vpc_cidr, var.private_cidr_range - local.vpc_cidr_range, i)
     ]
   )
   private_subnet_tags = {
@@ -33,7 +33,7 @@ module "cdp_vpc" {
   public_subnets = (local.subnets_required.public == 0 ?
     [] :
     [
-      for i in range(local.subnets_required.public) : cidrsubnet(var.vpc_cidr, ceil(log(local.subnets_required.total, 2)), i)
+      for i in range(local.subnets_required.public) : cidrsubnet(var.vpc_cidr, var.public_cidr_range - local.vpc_cidr_range, i + local.public_subnet_offset)
     ]
   )
 

--- a/modules/terraform-cdp-aws-pre-reqs/modules/vpc/variables.tf
+++ b/modules/terraform-cdp-aws-pre-reqs/modules/vpc/variables.tf
@@ -18,6 +18,20 @@ variable "vpc_cidr" {
 
 }
 
+variable "private_cidr_range" {
+  type        = number
+  description = "Size of each private subnet"
+
+  default = 19
+}
+
+variable "public_cidr_range" {
+  type        = number
+  description = "Size of each public subnet"
+
+  default = 24
+}
+
 variable "tags" {
   type        = map(any)
   description = "Tags applied to provised resources"
@@ -46,3 +60,5 @@ variable "private_network_extensions" {
   description = "Enable creation of resources for connectivity to CDP Control Plane (public subnet and NAT Gateway) for Private Deployment. Only relevant for private deployment template."
 
 }
+
+  

--- a/modules/terraform-cdp-aws-pre-reqs/modules/vpc/variables.tf
+++ b/modules/terraform-cdp-aws-pre-reqs/modules/vpc/variables.tf
@@ -21,15 +21,11 @@ variable "vpc_cidr" {
 variable "private_cidr_range" {
   type        = number
   description = "Size of each private subnet"
-
-  default = 19
 }
 
 variable "public_cidr_range" {
   type        = number
   description = "Size of each public subnet"
-
-  default = 24
 }
 
 variable "tags" {

--- a/modules/terraform-cdp-aws-pre-reqs/variables.tf
+++ b/modules/terraform-cdp-aws-pre-reqs/variables.tf
@@ -90,9 +90,23 @@ variable "create_vpc" {
 
 variable "vpc_cidr" {
   type        = string
-  description = "VPC CIDR Block"
+  description = "VPC CIDR Block. Required if create_vpc is true."
 
   default = "10.10.0.0/16"
+}
+
+variable "private_cidr_range" {
+  type        = number
+  description = "Size of each private subnet. Required if create_vpc is true. Number of subnets will be automatically selected to match on the number of Availability Zones in the selected AWS region. (Depending on the selected deployment pattern, one subnet will be created per region.)"
+
+  default = 19
+}
+
+variable "public_cidr_range" {
+  type        = number
+  description = "Size of each public subnet. Required if create_vpc is true. Number of subnets will be automatically selected to match on the number of Availability Zones in the selected AWS region. (Depending on the selected deployment pattern, one subnet will be created per region.)"
+
+  default = 24
 }
 
 variable "private_network_extensions" {

--- a/modules/terraform-cdp-azure-pre-reqs/main.tf
+++ b/modules/terraform-cdp-azure-pre-reqs/main.tf
@@ -39,10 +39,10 @@ module "azure_cdp_vnet" {
 
   env_prefix = var.env_prefix
   tags       = local.env_tags
-  
-  cdp_subnet_range = var.cdp_subnet_range
+
+  cdp_subnet_range     = var.cdp_subnet_range
   gateway_subnet_range = var.gateway_subnet_range
-    
+
 }
 
 

--- a/modules/terraform-cdp-azure-pre-reqs/main.tf
+++ b/modules/terraform-cdp-azure-pre-reqs/main.tf
@@ -39,6 +39,10 @@ module "azure_cdp_vnet" {
 
   env_prefix = var.env_prefix
   tags       = local.env_tags
+  
+  cdp_subnet_range = var.cdp_subnet_range
+  gateway_subnet_range = var.gateway_subnet_range
+    
 }
 
 

--- a/modules/terraform-cdp-azure-pre-reqs/modules/vnet/defaults.tf
+++ b/modules/terraform-cdp-azure-pre-reqs/modules/vnet/defaults.tf
@@ -26,7 +26,7 @@ locals {
   # Extract the VNet CIDR range from the user-provided CIDR
   vnet_cidr_range = split("/",var.vnet_cidr)[1]
   
-  # Calculate the first suitable CIDR range for public subnets after CDP subnets have been allocated.
+  # Calculate the first suitable CIDR range for public subnets after private subnets have been allocated (normalize the offset, expressed as a multiplier of gateway subnet ranges)
   gateway_subnet_offset = ceil(local.subnets_required.cdp_subnets * pow(2, 32-var.cdp_subnet_range)/pow(2, 32-var.gateway_subnet_range))
 
 

--- a/modules/terraform-cdp-azure-pre-reqs/modules/vnet/defaults.tf
+++ b/modules/terraform-cdp-azure-pre-reqs/modules/vnet/defaults.tf
@@ -23,6 +23,7 @@ locals {
     # cidr            = cidrsubnet(var.vnet_cidr, ceil(log(var.subnet_count, 2)), idx)
   }
 
+  # Extract the VNet CIDR range from the user-provided CIDR
   vnet_cidr_range = split("/",var.vnet_cidr)[1]
   
   # Calculate the first suitable CIDR range for public subnets after CDP subnets have been allocated.

--- a/modules/terraform-cdp-azure-pre-reqs/modules/vnet/defaults.tf
+++ b/modules/terraform-cdp-azure-pre-reqs/modules/vnet/defaults.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 locals {
-  
+
   # Calculate subnets CIDR and names
   subnets_required = {
     total           = (var.deployment_template == "semi-private") ? var.subnet_count + 1 : var.subnet_count
@@ -24,10 +24,10 @@ locals {
   }
 
   # Extract the VNet CIDR range from the user-provided CIDR
-  vnet_cidr_range = split("/",var.vnet_cidr)[1]
-  
+  vnet_cidr_range = split("/", var.vnet_cidr)[1]
+
   # Calculate the first suitable CIDR range for public subnets after private subnets have been allocated (normalize the offset, expressed as a multiplier of gateway subnet ranges)
-  gateway_subnet_offset = ceil(local.subnets_required.cdp_subnets * pow(2, 32-var.cdp_subnet_range)/pow(2, 32-var.gateway_subnet_range))
+  gateway_subnet_offset = ceil(local.subnets_required.cdp_subnets * pow(2, 32 - var.cdp_subnet_range) / pow(2, 32 - var.gateway_subnet_range))
 
 
   # Network infrastructure for CDP resources

--- a/modules/terraform-cdp-azure-pre-reqs/modules/vnet/variables.tf
+++ b/modules/terraform-cdp-azure-pre-reqs/modules/vnet/variables.tf
@@ -40,6 +40,20 @@ variable "vnet_cidr" {
 
 }
 
+variable "cdp_subnet_range" {
+  type        = number
+  description = "Size of each (internal) cluster subnet"
+
+  default = 19
+}
+
+variable "gateway_subnet_range" {
+  type        = number
+  description = "Size of each gateway subnet"
+
+  default = 24  
+}
+
 variable "vnet_region" {
   type        = string
   description = "Region which VNet will be created"

--- a/modules/terraform-cdp-azure-pre-reqs/modules/vnet/variables.tf
+++ b/modules/terraform-cdp-azure-pre-reqs/modules/vnet/variables.tf
@@ -44,14 +44,12 @@ variable "cdp_subnet_range" {
   type        = number
   description = "Size of each (internal) cluster subnet"
 
-  default = 19
 }
 
 variable "gateway_subnet_range" {
   type        = number
   description = "Size of each gateway subnet"
 
-  default = 24  
 }
 
 variable "vnet_region" {

--- a/modules/terraform-cdp-azure-pre-reqs/variables.tf
+++ b/modules/terraform-cdp-azure-pre-reqs/variables.tf
@@ -39,12 +39,6 @@ variable "env_prefix" {
   description = "Shorthand name for the environment. Used in resource descriptions"
 }
 
-# variable "public_key_text" {
-#   type = string
-
-#   description = "SSH Public key string for the nodes of the CDP environment"
-# }
-# ------- CDP Environment Deployment -------
 variable "deployment_template" {
   type = string
 

--- a/modules/terraform-cdp-azure-pre-reqs/variables.tf
+++ b/modules/terraform-cdp-azure-pre-reqs/variables.tf
@@ -89,9 +89,23 @@ variable "vnet_name" {
 
 variable "vnet_cidr" {
   type        = string
-  description = "VNet CIDR Block"
+  description = "VNet CIDR Block. Required if create_vpc is true."
 
   default = "10.10.0.0/16"
+}
+
+variable "cdp_subnet_range" {
+  type        = number
+  description = "Size of each (internal) cluster subnet. Required if create_vpc is true."
+
+  default = 19
+}
+
+variable "gateway_subnet_range" {
+  type        = number
+  description = "Size of each gateway subnet. Required if create_vpc is true."
+
+  default = 24  
 }
 
 variable "cdp_resourcegroup_name" {

--- a/modules/terraform-cdp-azure-pre-reqs/variables.tf
+++ b/modules/terraform-cdp-azure-pre-reqs/variables.tf
@@ -99,7 +99,7 @@ variable "gateway_subnet_range" {
   type        = number
   description = "Size of each gateway subnet. Required if create_vpc is true."
 
-  default = 24  
+  default = 24
 }
 
 variable "cdp_resourcegroup_name" {


### PR DESCRIPTION
Currently, the prereq modules configure the vpc/cnet submodules in a way that the total VPC/VNet CIDR range is split up equally between the number of subnets created.

While this is a sound approach, it results in a networking layout that does not align with our recommended network settings (and the current "Create new VPC" feature of CDP) and may be a source of confusion. See also https://docs.cloudera.com/cdp-public-cloud/cloud/requirements-aws/topics/mc-aws-req-vpc.html

We should implement a logic where the user can select the size of the public/private (internal/gateway) subnets and the module calculates each subnet's CIDR range accordingly.

Defaults subnet sizes will be set according to the linked documentation (/19 for internal/private and /24 for public/CDP subnets)