### PR TITLE
Improve subnet CIDR calculation (clone of #23)

### DIFF
--- a/modules/terraform-cdp-aws-pre-reqs/main.tf
+++ b/modules/terraform-cdp-aws-pre-reqs/main.tf
@@ -26,6 +26,8 @@ module "aws_cdp_vpc" {
   env_prefix                 = var.env_prefix
   tags                       = local.env_tags
 
+  private_cidr_range = var.private_cidr_range
+  public_cidr_range  = var.public_cidr_range
 }
 
 # ------- Security Groups -------

--- a/modules/terraform-cdp-aws-pre-reqs/modules/vpc/defaults.tf
+++ b/modules/terraform-cdp-aws-pre-reqs/modules/vpc/defaults.tf
@@ -25,4 +25,10 @@ locals {
     public  = (var.deployment_template == "private") ? (var.private_network_extensions ? 1 : 0) : length(local.zones_in_region)
     private = (var.deployment_template == "public") ? 0 : length(local.zones_in_region)
   }
+
+  # Extract the VPC CIDR range from the user-provided CIDR
+  vpc_cidr_range = split("/", var.vpc_cidr)[1]
+
+  # Calculate the first suitable CIDR range for public subnets after private subnets have been allocated (normalize the offset, expressed as a multiplier of public subnet ranges)
+  public_subnet_offset = ceil(local.subnets_required.private * pow(2, 32 - var.private_cidr_range) / pow(2, 32 - var.public_cidr_range))
 }

--- a/modules/terraform-cdp-aws-pre-reqs/modules/vpc/main.tf
+++ b/modules/terraform-cdp-aws-pre-reqs/modules/vpc/main.tf
@@ -23,7 +23,7 @@ module "cdp_vpc" {
   private_subnets = (local.subnets_required.private == 0 ?
     [] :
     [
-      for i in range(local.subnets_required.private) : cidrsubnet(var.vpc_cidr, ceil(log(local.subnets_required.total, 2)), local.subnets_required.public + i)
+      for i in range(local.subnets_required.private) : cidrsubnet(var.vpc_cidr, var.private_cidr_range - local.vpc_cidr_range, i)
     ]
   )
   private_subnet_tags = {
@@ -33,7 +33,7 @@ module "cdp_vpc" {
   public_subnets = (local.subnets_required.public == 0 ?
     [] :
     [
-      for i in range(local.subnets_required.public) : cidrsubnet(var.vpc_cidr, ceil(log(local.subnets_required.total, 2)), i)
+      for i in range(local.subnets_required.public) : cidrsubnet(var.vpc_cidr, var.public_cidr_range - local.vpc_cidr_range, i + local.public_subnet_offset)
     ]
   )
 

--- a/modules/terraform-cdp-aws-pre-reqs/modules/vpc/variables.tf
+++ b/modules/terraform-cdp-aws-pre-reqs/modules/vpc/variables.tf
@@ -18,6 +18,16 @@ variable "vpc_cidr" {
 
 }
 
+variable "private_cidr_range" {
+  type        = number
+  description = "Size of each private subnet"
+}
+
+variable "public_cidr_range" {
+  type        = number
+  description = "Size of each public subnet"
+}
+
 variable "tags" {
   type        = map(any)
   description = "Tags applied to provised resources"
@@ -46,3 +56,5 @@ variable "private_network_extensions" {
   description = "Enable creation of resources for connectivity to CDP Control Plane (public subnet and NAT Gateway) for Private Deployment. Only relevant for private deployment template."
 
 }
+
+  

--- a/modules/terraform-cdp-aws-pre-reqs/variables.tf
+++ b/modules/terraform-cdp-aws-pre-reqs/variables.tf
@@ -90,9 +90,23 @@ variable "create_vpc" {
 
 variable "vpc_cidr" {
   type        = string
-  description = "VPC CIDR Block"
+  description = "VPC CIDR Block. Required if create_vpc is true."
 
   default = "10.10.0.0/16"
+}
+
+variable "private_cidr_range" {
+  type        = number
+  description = "Size of each private subnet. Required if create_vpc is true. Number of subnets will be automatically selected to match on the number of Availability Zones in the selected AWS region. (Depending on the selected deployment pattern, one subnet will be created per region.)"
+
+  default = 19
+}
+
+variable "public_cidr_range" {
+  type        = number
+  description = "Size of each public subnet. Required if create_vpc is true. Number of subnets will be automatically selected to match on the number of Availability Zones in the selected AWS region. (Depending on the selected deployment pattern, one subnet will be created per region.)"
+
+  default = 24
 }
 
 variable "private_network_extensions" {

--- a/modules/terraform-cdp-azure-pre-reqs/main.tf
+++ b/modules/terraform-cdp-azure-pre-reqs/main.tf
@@ -39,6 +39,10 @@ module "azure_cdp_vnet" {
 
   env_prefix = var.env_prefix
   tags       = local.env_tags
+
+  cdp_subnet_range     = var.cdp_subnet_range
+  gateway_subnet_range = var.gateway_subnet_range
+
 }
 
 

--- a/modules/terraform-cdp-azure-pre-reqs/modules/vnet/variables.tf
+++ b/modules/terraform-cdp-azure-pre-reqs/modules/vnet/variables.tf
@@ -40,6 +40,18 @@ variable "vnet_cidr" {
 
 }
 
+variable "cdp_subnet_range" {
+  type        = number
+  description = "Size of each (internal) cluster subnet"
+
+}
+
+variable "gateway_subnet_range" {
+  type        = number
+  description = "Size of each gateway subnet"
+
+}
+
 variable "vnet_region" {
   type        = string
   description = "Region which VNet will be created"

--- a/modules/terraform-cdp-azure-pre-reqs/variables.tf
+++ b/modules/terraform-cdp-azure-pre-reqs/variables.tf
@@ -39,12 +39,6 @@ variable "env_prefix" {
   description = "Shorthand name for the environment. Used in resource descriptions"
 }
 
-# variable "public_key_text" {
-#   type = string
-
-#   description = "SSH Public key string for the nodes of the CDP environment"
-# }
-# ------- CDP Environment Deployment -------
 variable "deployment_template" {
   type = string
 
@@ -89,9 +83,23 @@ variable "vnet_name" {
 
 variable "vnet_cidr" {
   type        = string
-  description = "VNet CIDR Block"
+  description = "VNet CIDR Block. Required if create_vpc is true."
 
   default = "10.10.0.0/16"
+}
+
+variable "cdp_subnet_range" {
+  type        = number
+  description = "Size of each (internal) cluster subnet. Required if create_vpc is true."
+
+  default = 19
+}
+
+variable "gateway_subnet_range" {
+  type        = number
+  description = "Size of each gateway subnet. Required if create_vpc is true."
+
+  default = 24
 }
 
 variable "cdp_resourcegroup_name" {


### PR DESCRIPTION
Currently, the prereq modules configure the vpc/cnet submodules in a way that the total VPC/VNet CIDR range is split up equally between the number of subnets created.

While this is a sound approach, it results in a networking layout that does not align with our recommended network settings (and the current "Create new VPC" feature of CDP) and may be a source of confusion. See also https://docs.cloudera.com/cdp-public-cloud/cloud/requirements-aws/topics/mc-aws-req-vpc.html

We should implement a logic where the user can select the size of the public/private (internal/gateway) subnets and the module calculates each subnet's CIDR range accordingly.

Defaults subnet sizes will be set according to the linked documentation (/19 for internal/private and /24 for public/CDP subnets)

---
This is a clone of PR #23, but all commits squashed into a single (signed) commit. It includes following original commits:

c59dc5f6da0b055356aefb5182585a1bb15a2907
d47b8b631d572e552016804fd54542f13dbc97fb
ddbdf93794566057ee8908017fe08480cdb921a5
f8a9e05fa2f9c4b131e1a13aa13a6e1c5ee1bf95
b0fe32cd49c753828dd956474aac3d1d734ca73e
04ec93b74222ecf8261419c805610ec549cf89f2
0714cd30c778fc3a57636e74ed1d0dbf5eb20e5a
5b3215c4c6d2bdb509896c82678ef131e13c8334