### PR TITLE
Add aws policy for iam:TagRole to xaccount role

### DIFF
--- a/modules/terraform-cdp-aws-pre-reqs/README.md
+++ b/modules/terraform-cdp-aws-pre-reqs/README.md
@@ -53,6 +53,7 @@ In each directory an example `terraform.tfvars.sample` values file is included t
 | [aws_iam_policy.cdp_datalake_admin_s3_data_access_policy](https://registry.terraform.io/providers/hashicorp/aws/4.67.0/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.cdp_datalake_backup_policy](https://registry.terraform.io/providers/hashicorp/aws/4.67.0/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.cdp_datalake_restore_policy](https://registry.terraform.io/providers/hashicorp/aws/4.67.0/docs/resources/iam_policy) | resource |
+| [aws_iam_policy.cdp_extra_xaccount_policy](https://registry.terraform.io/providers/hashicorp/aws/4.67.0/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.cdp_idbroker_policy](https://registry.terraform.io/providers/hashicorp/aws/4.67.0/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.cdp_log_bucket_data_access_policy](https://registry.terraform.io/providers/hashicorp/aws/4.67.0/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.cdp_log_data_access_policy](https://registry.terraform.io/providers/hashicorp/aws/4.67.0/docs/resources/iam_policy) | resource |
@@ -69,6 +70,7 @@ In each directory an example `terraform.tfvars.sample` values file is included t
 | [aws_iam_role_policy_attachment.cdp_datalake_admin_role_attach4](https://registry.terraform.io/providers/hashicorp/aws/4.67.0/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.cdp_datalake_admin_role_attach5](https://registry.terraform.io/providers/hashicorp/aws/4.67.0/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.cdp_datalake_admin_role_attach6](https://registry.terraform.io/providers/hashicorp/aws/4.67.0/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.cdp_extra_xaccount_attach](https://registry.terraform.io/providers/hashicorp/aws/4.67.0/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.cdp_idbroker_role_attach1](https://registry.terraform.io/providers/hashicorp/aws/4.67.0/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.cdp_idbroker_role_attach2](https://registry.terraform.io/providers/hashicorp/aws/4.67.0/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.cdp_log_role_attach1](https://registry.terraform.io/providers/hashicorp/aws/4.67.0/docs/resources/iam_role_policy_attachment) | resource |
@@ -106,6 +108,7 @@ In each directory an example `terraform.tfvars.sample` values file is included t
 | [time_sleep.iam_propagation](https://registry.terraform.io/providers/hashicorp/time/0.9.1/docs/resources/sleep) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/4.67.0/docs/data-sources/caller_identity) | data source |
 | [aws_iam_policy_document.cdp_datalake_admin_role_policy_doc](https://registry.terraform.io/providers/hashicorp/aws/4.67.0/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.cdp_extra_xaccount_policy_doc](https://registry.terraform.io/providers/hashicorp/aws/4.67.0/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.cdp_idbroker_policy_doc](https://registry.terraform.io/providers/hashicorp/aws/4.67.0/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.cdp_idbroker_role_policy_doc](https://registry.terraform.io/providers/hashicorp/aws/4.67.0/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.cdp_log_role_policy_doc](https://registry.terraform.io/providers/hashicorp/aws/4.67.0/docs/data-sources/iam_policy_document) | data source |
@@ -197,8 +200,10 @@ In each directory an example `terraform.tfvars.sample` values file is included t
 | <a name="output_aws_data_storage_location"></a> [aws\_data\_storage\_location](#output\_aws\_data\_storage\_location) | AWS data storage location |
 | <a name="output_aws_data_storage_object"></a> [aws\_data\_storage\_object](#output\_aws\_data\_storage\_object) | AWS data storage object |
 | <a name="output_aws_datalake_admin_role_arn"></a> [aws\_datalake\_admin\_role\_arn](#output\_aws\_datalake\_admin\_role\_arn) | Datalake Admin role ARN |
+| <a name="output_aws_datalake_admin_role_name"></a> [aws\_datalake\_admin\_role\_name](#output\_aws\_datalake\_admin\_role\_name) | Datalake Admin role Name |
 | <a name="output_aws_default_route_table_id"></a> [aws\_default\_route\_table\_id](#output\_aws\_default\_route\_table\_id) | AWS default route table ID |
 | <a name="output_aws_idbroker_instance_profile_arn"></a> [aws\_idbroker\_instance\_profile\_arn](#output\_aws\_idbroker\_instance\_profile\_arn) | IDBroker instance profile ARN |
+| <a name="output_aws_idbroker_role_name"></a> [aws\_idbroker\_role\_name](#output\_aws\_idbroker\_role\_name) | IDBroker role Name |
 | <a name="output_aws_log_instance_profile_arn"></a> [aws\_log\_instance\_profile\_arn](#output\_aws\_log\_instance\_profile\_arn) | Log instance profile ARN |
 | <a name="output_aws_log_role_name"></a> [aws\_log\_role\_name](#output\_aws\_log\_role\_name) | Log role Name |
 | <a name="output_aws_log_storage_bucket"></a> [aws\_log\_storage\_bucket](#output\_aws\_log\_storage\_bucket) | AWS log storage bucket |
@@ -209,11 +214,13 @@ In each directory an example `terraform.tfvars.sample` values file is included t
 | <a name="output_aws_public_route_table_ids"></a> [aws\_public\_route\_table\_ids](#output\_aws\_public\_route\_table\_ids) | AWS public route table IDs |
 | <a name="output_aws_public_subnet_ids"></a> [aws\_public\_subnet\_ids](#output\_aws\_public\_subnet\_ids) | AWS public subnet IDs |
 | <a name="output_aws_ranger_audit_role_arn"></a> [aws\_ranger\_audit\_role\_arn](#output\_aws\_ranger\_audit\_role\_arn) | Ranger Audit role ARN |
+| <a name="output_aws_ranger_audit_role_name"></a> [aws\_ranger\_audit\_role\_name](#output\_aws\_ranger\_audit\_role\_name) | Ranger Audit role Name |
 | <a name="output_aws_region"></a> [aws\_region](#output\_aws\_region) | Cloud provider region of the Environment |
 | <a name="output_aws_security_group_default_id"></a> [aws\_security\_group\_default\_id](#output\_aws\_security\_group\_default\_id) | AWS security group id for default CDP SG |
 | <a name="output_aws_security_group_knox_id"></a> [aws\_security\_group\_knox\_id](#output\_aws\_security\_group\_knox\_id) | AWS security group id for Knox CDP SG |
 | <a name="output_aws_vpc_id"></a> [aws\_vpc\_id](#output\_aws\_vpc\_id) | AWS VPC ID |
 | <a name="output_aws_vpc_subnets"></a> [aws\_vpc\_subnets](#output\_aws\_vpc\_subnets) | List of subnets associated with the CDP VPC |
 | <a name="output_aws_xaccount_role_arn"></a> [aws\_xaccount\_role\_arn](#output\_aws\_xaccount\_role\_arn) | Cross Account role ARN |
+| <a name="output_aws_xaccount_role_name"></a> [aws\_xaccount\_role\_name](#output\_aws\_xaccount\_role\_name) | Cross Account role name |
 | <a name="output_tags"></a> [tags](#output\_tags) | Tags associated with the environment and its resources |
 <!-- END_TF_DOCS -->

--- a/modules/terraform-cdp-aws-pre-reqs/main.tf
+++ b/modules/terraform-cdp-aws-pre-reqs/main.tf
@@ -1,4 +1,4 @@
-# Copyright 2023 Cloudera, Inc. All Rights Reserved.
+# Copyright 2024 Cloudera, Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -769,4 +769,37 @@ resource "aws_iam_role_policy_attachment" "cdp_ranger_audit_role_attach6" {
 
   role       = aws_iam_role.cdp_ranger_audit_role.name
   policy_arn = aws_iam_policy.cdp_datalake_restore_policy.arn
+}
+
+# ------- Add missing iam:Tag* permissions to Cross-Account Policy -------
+# First create the extra policy document
+data "aws_iam_policy_document" "cdp_extra_xaccount_policy_doc" {
+  version = "2012-10-17"
+
+  statement {
+    sid = "AllowIAMTagRole"
+
+    actions = ["iam:TagRole"]
+    effect  = "Allow"
+
+    resources = [
+      "*",
+    ]
+  }
+}
+
+# Then create the policy using the document
+resource "aws_iam_policy" "cdp_extra_xaccount_policy" {
+  name        = "${var.env_prefix}-cross-account-extra"
+  description = "Additional Cross Account Policy for ${var.env_prefix}"
+
+  tags = { Name = "${var.env_prefix}-cross-account-extra" }
+
+  policy = data.aws_iam_policy_document.cdp_extra_xaccount_policy_doc.json
+}
+
+# Attach this policy to the cross account role
+resource "aws_iam_role_policy_attachment" "cdp_extra_xaccount_attach" {
+  role       = aws_iam_role.cdp_xaccount_role.name
+  policy_arn = aws_iam_policy.cdp_extra_xaccount_policy.arn
 }

--- a/modules/terraform-cdp-aws-pre-reqs/outputs.tf
+++ b/modules/terraform-cdp-aws-pre-reqs/outputs.tf
@@ -1,4 +1,4 @@
-# Copyright 2023 Cloudera, Inc. All Rights Reserved.
+# Copyright 2024 Cloudera, Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -151,10 +151,34 @@ output "aws_xaccount_role_arn" {
   description = "Cross Account role ARN"
 }
 
+output "aws_xaccount_role_name" {
+  value = aws_iam_role.cdp_xaccount_role.name
+
+  description = "Cross Account role name"
+}
+
 output "aws_log_role_name" {
   value = aws_iam_role.cdp_log_role.name
 
   description = "Log role Name"
+}
+
+output "aws_idbroker_role_name" {
+  value = aws_iam_role.cdp_idbroker_role.name
+
+  description = "IDBroker role Name"
+}
+
+output "aws_datalake_admin_role_name" {
+  value = aws_iam_role.cdp_datalake_admin_role.name
+
+  description = "Datalake Admin role Name"
+}
+
+output "aws_ranger_audit_role_name" {
+  value = aws_iam_role.cdp_ranger_audit_role.name
+
+  description = "Ranger Audit role Name"
 }
 
 output "aws_log_instance_profile_arn" {

--- a/modules/terraform-cdp-deploy/examples/ex01-aws-basic/main.tf
+++ b/modules/terraform-cdp-deploy/examples/ex01-aws-basic/main.tf
@@ -39,6 +39,9 @@ module "cdp_aws_prereqs" {
   # Inputs for Control Plane Connectivity in fully private 
   private_network_extensions = var.private_network_extensions
 
+  # Tags to apply resources (omitted by default)
+  env_tags = var.env_tags
+
 }
 
 module "cdp_deploy" {
@@ -71,6 +74,9 @@ module "cdp_deploy" {
 
   aws_log_instance_profile_arn      = module.cdp_aws_prereqs.aws_log_instance_profile_arn
   aws_idbroker_instance_profile_arn = module.cdp_aws_prereqs.aws_idbroker_instance_profile_arn
+
+  # Tags to apply resources (omitted by default)
+  env_tags = var.env_tags
 
   depends_on = [
     module.cdp_aws_prereqs

--- a/modules/terraform-cdp-deploy/examples/ex01-aws-basic/terraform.tfvars.sample
+++ b/modules/terraform-cdp-deploy/examples/ex01-aws-basic/terraform.tfvars.sample
@@ -22,6 +22,14 @@ aws_key_pair = "<ENTER_VALUE>" # Change this with the name of a pre-existing AWS
 # ------- CDP Environment Deployment -------
 deployment_template = "<ENTER_VALUE>"  # Specify the deployment pattern below. Options are public, semi-private or private
 
+# ------- Resource Tagging -------
+# **NOTE: An example of how to specify tags is below; uncomment & edit if required
+# env_tags = {
+#     owner   = "<ENTER_VALUE>"
+#     project = "<ENTER_VALUE>"
+#     enddate = "<ENTER_VALUE>"
+# }
+
 # ------- Network Settings -------
 # **NOTE: If required change the values below any additional CIDRs to add the the AWS Security Groups**
 ingress_extra_cidrs_and_ports = {

--- a/modules/terraform-cdp-deploy/examples/ex01-aws-basic/variables.tf
+++ b/modules/terraform-cdp-deploy/examples/ex01-aws-basic/variables.tf
@@ -38,6 +38,13 @@ variable "aws_key_pair" {
 
 }
 
+variable "env_tags" {
+  type        = map(any)
+  description = "Tags applied to pvovisioned resources"
+
+  default = null
+}
+
 # ------- CDP Environment Deployment -------
 variable "deployment_template" {
   type = string

--- a/modules/terraform-cdp-deploy/examples/ex02-azure-basic/main.tf
+++ b/modules/terraform-cdp-deploy/examples/ex02-azure-basic/main.tf
@@ -40,6 +40,9 @@ module "cdp_azure_prereqs" {
   cdp_subnet_names       = var.cdp_subnet_names
   cdp_gw_subnet_names    = var.cdp_gw_subnet_names
 
+  # Tags to apply resources (omitted by default)
+  env_tags = var.env_tags
+
 }
 
 module "cdp_deploy" {
@@ -81,6 +84,9 @@ module "cdp_deploy" {
   azure_ranger_audit_identity_id  = module.cdp_azure_prereqs.azure_ranger_audit_identity_id
   azure_log_identity_id           = module.cdp_azure_prereqs.azure_log_identity_id
   azure_raz_identity_id           = module.cdp_azure_prereqs.azure_raz_identity_id
+
+  # Tags to apply resources (omitted by default)
+  env_tags = var.env_tags
 
   depends_on = [
     module.cdp_azure_prereqs

--- a/modules/terraform-cdp-deploy/examples/ex02-azure-basic/terraform.tfvars.sample
+++ b/modules/terraform-cdp-deploy/examples/ex02-azure-basic/terraform.tfvars.sample
@@ -23,6 +23,14 @@ public_key_text = "<ENTER_VALUE>" # Change this with the SSH public key text, e.
 # ------- CDP Environment Deployment -------
 deployment_template = "<ENTER_VALUE>"  # Specify the deployment pattern below. Options are public, semi-private or private
 
+# ------- Resource Tagging -------
+# **NOTE: An example of how to specify tags is below; uncomment & edit if required
+# env_tags = {
+#     owner   = "<ENTER_VALUE>"
+#     project = "<ENTER_VALUE>"
+#     enddate = "<ENTER_VALUE>"
+# }
+
 # ------- Network Settings -------
 # **NOTE: If required change the values below any additional CIDRs to add the the AWS Security Groups**
 ingress_extra_cidrs_and_ports = {

--- a/modules/terraform-cdp-deploy/examples/ex02-azure-basic/variables.tf
+++ b/modules/terraform-cdp-deploy/examples/ex02-azure-basic/variables.tf
@@ -29,6 +29,13 @@ variable "public_key_text" {
   description = "SSH Public key string for the nodes of the CDP environment"
 }
 
+variable "env_tags" {
+  type        = map(any)
+  description = "Tags applied to pvovisioned resources"
+
+  default = null
+}
+
 # ------- CDP Environment Deployment -------
 variable "deployment_template" {
   type = string

--- a/modules/terraform-cdp-deploy/examples/ex03-gcp-basic/main.tf
+++ b/modules/terraform-cdp-deploy/examples/ex03-gcp-basic/main.tf
@@ -66,6 +66,9 @@ module "cdp_deploy" {
   gcp_ranger_audit_service_account_email   = module.cdp_gcp_prereqs.gcp_ranger_audit_service_account_email
   gcp_log_service_account_email            = module.cdp_gcp_prereqs.gcp_log_service_account_email
 
+  # Tags to apply resources (omitted by default)
+  env_tags = var.env_tags
+
   depends_on = [
     module.cdp_gcp_prereqs
   ]

--- a/modules/terraform-cdp-deploy/examples/ex03-gcp-basic/terraform.tfvars.sample
+++ b/modules/terraform-cdp-deploy/examples/ex03-gcp-basic/terraform.tfvars.sample
@@ -25,6 +25,14 @@ public_key_text = "<ENTER_VALUE>" # Change this with the SSH public key text, e.
 # ------- CDP Environment Deployment -------
 deployment_template = "<ENTER_VALUE>"  # Specify the deployment pattern below. Options are public, semi-private or private
 
+# ------- Resource Tagging -------
+# **NOTE: An example of how to specify tags is below; uncomment & edit if required
+# env_tags = {
+#     owner   = "<ENTER_VALUE>"
+#     project = "<ENTER_VALUE>"
+#     enddate = "<ENTER_VALUE>"
+# }
+
 # ------- Network Settings -------
 # **NOTE: If required change the values below any additional CIDRs to add the the AWS Security Groups**
 ingress_extra_cidrs_and_ports = {

--- a/modules/terraform-cdp-deploy/examples/ex03-gcp-basic/variables.tf
+++ b/modules/terraform-cdp-deploy/examples/ex03-gcp-basic/variables.tf
@@ -34,6 +34,13 @@ variable "public_key_text" {
   description = "SSH Public key string for the nodes of the CDP environment"
 }
 
+variable "env_tags" {
+  type        = map(any)
+  description = "Tags applied to pvovisioned resources"
+
+  default = null
+}
+
 # ------- CDP Environment Deployment -------
 variable "deployment_template" {
   type = string


### PR DESCRIPTION
A workaround to add the iam:TagRole permission to the cross account role. This allows successful deployment of data services on Terraform deployed environments.