### PR TITLE
Update tflint config option

### DIFF
--- a/.tflint.hcl
+++ b/.tflint.hcl
@@ -37,7 +37,7 @@ plugin "google" {
 }
 
 config {
-  module = true
+  call_module_type = "local"
   force  = false
 }
 


### PR DESCRIPTION
`config.module` parameter has been deprecated in [latest release](https://github.com/terraform-linters/tflint/releases/tag/v0.54.0).

Advice is to use `call-module-type` instead - https://github.com/terraform-linters/tflint/blob/master/docs/user-guide/calling-modules.md
