### PR TITLE
Resolve deprecated storage account parameters in AzureRM provider

### DIFF
--- a/modules/terraform-azure-nfs/main.tf
+++ b/modules/terraform-azure-nfs/main.tf
@@ -24,10 +24,10 @@ resource "azurerm_storage_account" "nfs_storage_account" {
 
 
 resource "azurerm_storage_share" "nfs_storage_share" {
-  name                 = var.nfs_file_share_name
-  storage_account_name = azurerm_storage_account.nfs_storage_account.name
-  enabled_protocol     = "NFS"
-  quota                = var.nfs_file_share_size
+  name               = var.nfs_file_share_name
+  storage_account_id = azurerm_storage_account.nfs_storage_account.id
+  enabled_protocol   = "NFS"
+  quota              = var.nfs_file_share_size
 }
 
 

--- a/modules/terraform-cdp-azure-pre-reqs/main.tf
+++ b/modules/terraform-cdp-azure-pre-reqs/main.tf
@@ -135,7 +135,7 @@ resource "azurerm_storage_account" "cdp_storage_locations" {
 resource "azurerm_storage_container" "cdp_data_storage" {
 
   name                  = local.data_storage.data_storage_object
-  storage_account_name  = "${local.data_storage.data_storage_bucket}${local.storage_suffix}"
+  storage_account_id    = azurerm_storage_account.cdp_storage_locations[local.data_storage.data_storage_bucket].id
   container_access_type = "private"
 
   depends_on = [
@@ -147,7 +147,7 @@ resource "azurerm_storage_container" "cdp_data_storage" {
 resource "azurerm_storage_container" "cdp_log_storage" {
 
   name                  = local.log_storage.log_storage_object
-  storage_account_name  = "${local.log_storage.log_storage_bucket}${local.storage_suffix}"
+  storage_account_id    = azurerm_storage_account.cdp_storage_locations[local.log_storage.log_storage_bucket].id
   container_access_type = "private"
 
   depends_on = [
@@ -159,7 +159,7 @@ resource "azurerm_storage_container" "cdp_log_storage" {
 resource "azurerm_storage_container" "cdp_backup_storage" {
 
   name                  = local.backup_storage.backup_storage_object
-  storage_account_name  = "${local.backup_storage.backup_storage_bucket}${local.storage_suffix}"
+  storage_account_id    = azurerm_storage_account.cdp_storage_locations[local.backup_storage.backup_storage_bucket].id
   container_access_type = "private"
 
   depends_on = [
@@ -258,7 +258,7 @@ resource "azurerm_role_assignment" "cdp_datalake_admin_data_container_assign" {
 
   for_each = { for idx, role in var.datalake_admin_data_container_role_assignments : idx => role }
 
-  scope                = azurerm_storage_container.cdp_data_storage.resource_manager_id
+  scope                = azurerm_storage_container.cdp_data_storage.id
   role_definition_name = each.value.role
   principal_id         = azurerm_user_assigned_identity.cdp_datalake_admin.principal_id
 
@@ -270,7 +270,7 @@ resource "azurerm_role_assignment" "cdp_datalake_admin_log_container_assign" {
 
   for_each = { for idx, role in var.datalake_admin_log_container_role_assignments : idx => role }
 
-  scope                = azurerm_storage_container.cdp_log_storage.resource_manager_id
+  scope                = azurerm_storage_container.cdp_log_storage.id
   role_definition_name = each.value.role
   principal_id         = azurerm_user_assigned_identity.cdp_datalake_admin.principal_id
 
@@ -282,7 +282,7 @@ resource "azurerm_role_assignment" "cdp_datalake_admin_backup_container_assign" 
 
   for_each = { for idx, role in var.datalake_admin_backup_container_role_assignments : idx => role }
 
-  scope                = azurerm_storage_container.cdp_backup_storage.resource_manager_id
+  scope                = azurerm_storage_container.cdp_backup_storage.id
   role_definition_name = each.value.role
   principal_id         = azurerm_user_assigned_identity.cdp_datalake_admin.principal_id
 
@@ -305,7 +305,7 @@ resource "azurerm_role_assignment" "cdp_log_data_access_log_container_assign" {
 
   for_each = { for idx, role in var.log_data_access_role_assignments : idx => role }
 
-  scope                = azurerm_storage_container.cdp_log_storage.resource_manager_id
+  scope                = azurerm_storage_container.cdp_log_storage.id
   role_definition_name = each.value.role
   principal_id         = azurerm_user_assigned_identity.cdp_log_data_access.principal_id
 
@@ -316,7 +316,7 @@ resource "azurerm_role_assignment" "cdp_log_data_access_backup_container_assign"
 
   for_each = { for idx, role in var.log_data_access_role_assignments : idx => role }
 
-  scope                = azurerm_storage_container.cdp_backup_storage.resource_manager_id
+  scope                = azurerm_storage_container.cdp_backup_storage.id
   role_definition_name = each.value.role
   principal_id         = azurerm_user_assigned_identity.cdp_log_data_access.principal_id
 
@@ -339,7 +339,7 @@ resource "azurerm_role_assignment" "cdp_ranger_audit_data_container_assign" {
 
   for_each = { for idx, role in var.ranger_audit_data_container_role_assignments : idx => role }
 
-  scope                = azurerm_storage_container.cdp_data_storage.resource_manager_id
+  scope                = azurerm_storage_container.cdp_data_storage.id
   role_definition_name = each.value.role
   principal_id         = azurerm_user_assigned_identity.cdp_ranger_audit_data_access.principal_id
 
@@ -350,7 +350,7 @@ resource "azurerm_role_assignment" "cdp_ranger_audit_log_container_assign" {
 
   for_each = { for idx, role in var.ranger_audit_log_container_role_assignments : idx => role }
 
-  scope                = azurerm_storage_container.cdp_log_storage.resource_manager_id
+  scope                = azurerm_storage_container.cdp_log_storage.id
   role_definition_name = each.value.role
   principal_id         = azurerm_user_assigned_identity.cdp_ranger_audit_data_access.principal_id
 
@@ -361,7 +361,7 @@ resource "azurerm_role_assignment" "cdp_ranger_audit_backup_container_assign" {
 
   for_each = { for idx, role in var.ranger_audit_backup_container_role_assignments : idx => role }
 
-  scope                = azurerm_storage_container.cdp_backup_storage.resource_manager_id
+  scope                = azurerm_storage_container.cdp_backup_storage.id
   role_definition_name = each.value.role
   principal_id         = azurerm_user_assigned_identity.cdp_ranger_audit_data_access.principal_id
 

--- a/modules/terraform-cdp-azure-pre-reqs/outputs.tf
+++ b/modules/terraform-cdp-azure-pre-reqs/outputs.tf
@@ -84,7 +84,7 @@ output "azure_security_group_knox_uri" {
 }
 
 output "azure_data_storage_account" {
-  value = azurerm_storage_container.cdp_data_storage.storage_account_name
+  value = azurerm_storage_account.cdp_storage_locations[local.data_storage.data_storage_bucket].name
 
   description = "Azure data storage account name"
 }
@@ -96,14 +96,14 @@ output "azure_data_storage_container" {
 }
 
 output "azure_data_storage_location" {
-  value = "abfs://${azurerm_storage_container.cdp_data_storage.name}@${azurerm_storage_container.cdp_data_storage.storage_account_name}.dfs.core.windows.net"
+  value = "abfs://${azurerm_storage_container.cdp_data_storage.name}@${azurerm_storage_account.cdp_storage_locations[local.data_storage.data_storage_bucket].name}.dfs.core.windows.net"
 
   description = "Azure data storage location"
 
 }
 
 output "azure_log_storage_account" {
-  value = azurerm_storage_container.cdp_log_storage.storage_account_name
+  value = azurerm_storage_account.cdp_storage_locations[local.log_storage.log_storage_bucket].name
 
   description = "Azure log storage account name"
 }
@@ -115,14 +115,14 @@ output "azure_log_storage_container" {
 }
 
 output "azure_log_storage_location" {
-  value = "abfs://${azurerm_storage_container.cdp_log_storage.name}@${azurerm_storage_container.cdp_log_storage.storage_account_name}.dfs.core.windows.net"
+  value = "abfs://${azurerm_storage_container.cdp_log_storage.name}@${azurerm_storage_account.cdp_storage_locations[local.log_storage.log_storage_bucket].name}.dfs.core.windows.net"
 
   description = "Azure log storage location"
 
 }
 
 output "azure_backup_storage_account" {
-  value = azurerm_storage_container.cdp_backup_storage.storage_account_name
+  value = azurerm_storage_account.cdp_storage_locations[local.backup_storage.backup_storage_bucket].name
 
   description = "Azure backup storage account name"
 }
@@ -134,7 +134,8 @@ output "azure_backup_storage_container" {
 }
 
 output "azure_backup_storage_location" {
-  value = "abfs://${azurerm_storage_container.cdp_backup_storage.name}@${azurerm_storage_container.cdp_backup_storage.storage_account_name}.dfs.core.windows.net"
+  value = "abfs://${azurerm_storage_container.cdp_backup_storage.name}@${azurerm_storage_account.cdp_storage_locations[local.backup_storage.backup_storage_bucket].name}.dfs.core.windows.net"
+
 
   description = "Azure backup storage location"
 


### PR DESCRIPTION
Some output parameters related to Azure storage account resource are due to be deprecated in release 5.0 of the azurerm provider. This PR updates the resources to use the new recommended parameters.