### PR TITLE
Remove DL restore policy attachment from log role

### DIFF
--- a/modules/terraform-aws-permissions/main.tf
+++ b/modules/terraform-aws-permissions/main.tf
@@ -171,13 +171,6 @@ resource "aws_iam_role_policy_attachment" "cdp_log_role_attach1" {
   policy_arn = aws_iam_policy.cdp_log_data_access_policy.arn
 }
 
-# Attach AWS Datalake Restore Policy to the Role
-resource "aws_iam_role_policy_attachment" "cdp_log_role_attach2" {
-
-  role       = aws_iam_role.cdp_log_role.name
-  policy_arn = aws_iam_policy.cdp_datalake_restore_policy.arn
-}
-
 # Attach AWS Datalake Backup Policy to the Role
 resource "aws_iam_role_policy_attachment" "cdp_log_role_attach3" {
   role       = aws_iam_role.cdp_log_role.name


### PR DESCRIPTION
Since DL version 7.2.17, the datalake restore AWS IAM policy no longer needs to be attached to the log role.

See Cloudera on Cloudera  documentation [here](https://docs.cloudera.com/cdp-public-cloud/cloud/requirements-aws/topics/mc-idbroker-minimum-setup.html#:~:text=IDBroker%20EC2%20instance.-,LOG_ROLE,-aws-cdp-log) for more details.