### PR TITLE
CB-31466 aws_security_group_rule.cidr_blocks does not support multiple cidrs

### DIFF
--- a/modules/terraform-cdp-aws-pre-reqs/defaults.tf
+++ b/modules/terraform-cdp-aws-pre-reqs/defaults.tf
@@ -31,13 +31,13 @@ locals {
   prefix_list_name = coalesce(var.prefix_list_name, "${var.env_prefix}-prefix-list")
 
   security_group_rules_ingress = [
-    {
-      # CIDR ingress
-      cidr     = module.aws_cdp_vpc.vpc_cidr_blocks,
-      port     = "0",
-      protocol = "all"
-    }
-  ]
+  for cidr in module.aws_cdp_vpc.vpc_cidr_blocks : {
+    # CIDR ingress
+    cidr     = cidr
+    port     = "0"
+    protocol = "all"
+  }
+]
 
   # ------- Storage Resources -------
   storage_suffix = var.random_id_for_bucket ? "-${one(random_id.bucket_suffix).hex}" : ""

--- a/modules/terraform-cdp-aws-pre-reqs/main.tf
+++ b/modules/terraform-cdp-aws-pre-reqs/main.tf
@@ -96,16 +96,15 @@ resource "aws_security_group_rule" "cdp_endpoint_ingress_self" {
 }
 
 # Create security group rules from combining the default and extra list of ingress rules
-resource "aws_security_group_rule" "cdp_endpoint_sg_ingress" {
-  count = (var.create_vpc && var.create_vpc_endpoints) ? length(local.security_group_rules_ingress) : 0
+resource "aws_vpc_security_group_ingress_rule" "cdp_endpoint_sg_ingress" {
+  count = length(local.security_group_rules_ingress)
 
   description       = "Ingress rules for Endpoint Security Group"
   security_group_id = aws_security_group.cdp_endpoint_sg[0].id
-  type              = "ingress"
-  cidr_blocks       = tolist(local.security_group_rules_ingress)[count.index].cidr
-  from_port         = tolist(local.security_group_rules_ingress)[count.index].port
-  to_port           = tolist(local.security_group_rules_ingress)[count.index].port
-  protocol          = tolist(local.security_group_rules_ingress)[count.index].protocol
+  cidr_ipv4         = local.security_group_rules_ingress[count.index].cidr
+  ip_protocol       = local.security_group_rules_ingress[count.index].protocol
+  from_port         = local.security_group_rules_ingress[count.index].port
+  to_port           = local.security_group_rules_ingress[count.index].port
 }
 
 # Terraform removes the default ALLOW ALL egress. Let's recreate this


### PR DESCRIPTION
Using 'aws_vpc_security_group_ingress_rule' instead of aws_security_group_rule, as the latter does not in fact support multiple CIDRs in a single rule. It is misleading, but the documentation mentions this limitation:

> Avoid using the aws_security_group_rule resource, as it struggles with managing multiple CIDR blocks, and, due to the historical lack of unique IDs, tags and descriptions. To avoid these problems, use the current best practice of the aws_vpc_security_group_egress_rule and aws_vpc_security_group_ingress_rule resources with one CIDR block per rule.


https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule